### PR TITLE
Have write return the updated value, add write_ for void write

### DIFF
--- a/src/Effect/Ref.js
+++ b/src/Effect/Ref.js
@@ -26,7 +26,7 @@ exports.write = function (val) {
   return function (ref) {
     return function () {
       ref.value = val;
-      return {};
+      return val;
     };
   };
 };

--- a/src/Effect/Ref.purs
+++ b/src/Effect/Ref.purs
@@ -27,8 +27,14 @@ foreign import modify' :: forall s b. (s -> { state :: s, value :: b }) -> Ref s
 modify :: forall s. (s -> s) -> Ref s -> Effect s
 modify f = modify' \s -> let s' = f s in { state: s', value: s' }
 
+-- | Equivalent to `modify`, but returns `Unit`.
 modify_ :: forall s. (s -> s) -> Ref s -> Effect Unit
 modify_ f s = void $ modify f s
 
 -- | Update the value of a mutable reference to the specified value.
-foreign import write :: forall s. s -> Ref s -> Effect Unit
+-- | The updated value is returned.
+foreign import write :: forall s. s -> Ref s -> Effect s
+
+-- | Equivalent to `write`, but returns `Unit`.
+write_ :: forall s. s -> Ref s -> Effect Unit
+write_ f s = void $ write f s

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -16,15 +16,16 @@ main = do
   assertEqual { actual: curr1, expected: 0 }
 
   -- write over the ref with 1
-  Ref.write 1 ref
+  curr2 <- Ref.write 1 ref
+  assertEqual { actual: curr2, expected: 1 }
 
   -- now it is 1 when we read out the value
-  curr2 <- Ref.read ref
-  assertEqual { actual: curr2, expected: 1 }
+  curr3 <- Ref.read ref
+  assertEqual { actual: curr3, expected: 1 }
 
   -- modify it by adding 1 to the current state
   Ref.modify_ (\s -> s + 1) ref
 
   -- now it is 2 when we read out the value
-  curr3 <- Ref.read ref
-  assertEqual { actual: curr3, expected: 2 }
+  curr4 <- Ref.read ref
+  assertEqual { actual: curr4, expected: 2 }


### PR DESCRIPTION
0d9a1f9d changed `modify` such that it returns the updated value. 35dd2749 then added `modify_` which is equal to the old `modify`.

This PR makes the same changes to to `writer`. To me this seems to increase consistency in the API. Now `writer` and `modify` again returns the same thing and they both have an equivalent variant postfixed with `_`. Besides increasing consistency the changed `writer` also seems useful when writing into a ref with a complex expression. Then one can do this

```
resultOfComplexExpression = write (complexExpression) ref
```

Which is convenient :smile: