### PR TITLE
Add roles declarations to allow safe coercions

### DIFF
--- a/src/Effect/Ref.purs
+++ b/src/Effect/Ref.purs
@@ -20,6 +20,8 @@ import Effect (Effect)
 -- | which holds a value of type `a`.
 foreign import data Ref :: Type -> Type
 
+type role Ref representational
+
 -- | Create a new mutable reference containing the specified value.
 foreign import new :: forall s. s -> Effect (Ref s)
 


### PR DESCRIPTION
This allows terms of type `Ref a` to be coerced to type `Ref b` when `Coercible a b` holds, hence allowing the zero cost `coerce` instead of `map wrap` and `map unwrap` to introduce and eliminate newtypes under mutable references for instance.