### PR TITLE
Explain why Ref functions return `Effect (Ref s)` rather than `Ref s`

### DIFF
--- a/src/Effect/Ref.purs
+++ b/src/Effect/Ref.purs
@@ -2,6 +2,38 @@
 -- |
 -- | _Note_: `Control.Monad.ST` provides a _safe_ alternative to `Ref` when
 -- | mutation is restricted to a local scope.
+-- |
+-- | You'll notice that all of the functions that operate on a `Ref`
+-- | (e.g. `new`, `modify`, `modify_`, `read`) return an `Effect (Ref s)`
+-- | and not a `Ref s`. Here's what would happe if the `Ref s` was not
+-- | wrapped in an `Effect`:
+-- | 1. In some situations, one could violate referential transparency.
+-- | 2. One can violate the type system by giving a `Ref` a polymorphic type
+-- |    and then specializing it after the fact.
+-- |
+-- | In regards to the first, consider the below example:
+-- | ```
+-- | let
+-- |   x = Ref.new “hi”
+-- |   first = Tuple x x
+-- |   second = Tuple (Ref.new "hi") (Ref.new "hi")
+-- | ```
+-- | In the above code, `first` would be the same as `second` if it upheld
+-- | referential transparency. However, `first` holds the same reference twice
+-- | whereas `second` holds two different references. Thus, it invalidates
+-- | referential transparency. By making `Ref.new` return an `Effect`, a
+-- | new separate reference is created each time.
+-- |
+-- | In regards to the second, consider the below example:
+-- | ```
+-- | let
+-- |   ref :: forall a. Ref (Maybe a)
+-- |   ref = Ref.new Nothing
+-- | in
+-- |   Tuple (ref :: Ref (Maybe Int)) (ref :: Ref (Maybe String))
+-- | ```
+-- | The Tuple stores the same reference twice, but its type is `Maybe Int` in
+-- | one situation and `Maybe String` in another.
 module Effect.Ref
   ( Ref
   , new

--- a/src/Effect/Ref.purs
+++ b/src/Effect/Ref.purs
@@ -21,8 +21,9 @@
 -- | In the above code, `first` would be the same as `second` if it upheld
 -- | referential transparency. However, `first` holds the same reference twice
 -- | whereas `second` holds two different references. Thus, it invalidates
--- | referential transparency. By making `Ref.new` return an `Effect`, a
--- | new separate reference is created each time.
+-- | referential transparency. By making `Ref.new` return an `Effect`, we
+-- | return an _action_. Each time this action is called, it will create a new
+-- | separate reference that is initialized to the given value.
 -- |
 -- | In regards to the second, consider the below example:
 -- | ```

--- a/src/Effect/Ref.purs
+++ b/src/Effect/Ref.purs
@@ -18,12 +18,13 @@
 -- |   first = Tuple x x
 -- |   second = Tuple (Ref.new "hi") (Ref.new "hi")
 -- | ```
--- | In the above code, `first` would be the same as `second` if it upheld
--- | referential transparency. However, `first` holds the same reference twice
--- | whereas `second` holds two different references. Thus, it invalidates
--- | referential transparency. By making `Ref.new` return an `Effect`, we
--- | return an _action_. Each time this action is called, it will create a new
--- | separate reference that is initialized to the given value.
+-- | In the above code, `first` holds the same reference twice whereas `second`
+-- | holds two different references. Thus, it invalidates referential
+-- | transparency. If `first` was referentially transparent to `second`,
+-- | then `first` would hold two separate references just like `second`.
+-- | By making `Ref.new` return an `Effect`, we return an _action_. Each time
+-- | this action is called, it will create a new separate reference that is
+-- | initialized to the given value.
 -- |
 -- | In regards to the second, consider the below example:
 -- | ```

--- a/src/Effect/Ref.purs
+++ b/src/Effect/Ref.purs
@@ -5,7 +5,7 @@
 -- |
 -- | You'll notice that all of the functions that operate on a `Ref`
 -- | (e.g. `new`, `modify`, `modify_`, `read`) return an `Effect (Ref s)`
--- | and not a `Ref s`. Here's what would happe if the `Ref s` was not
+-- | and not a `Ref s`. Here's what would happen if the `Ref s` was not
 -- | wrapped in an `Effect`:
 -- | 1. In some situations, one could violate referential transparency.
 -- | 2. One can violate the type system by giving a `Ref` a polymorphic type


### PR DESCRIPTION
Fixes #23 